### PR TITLE
fix: re-add missing default.project.json

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,0 +1,15 @@
+{
+  "name": "Roblox-Project-Reforged",
+  "tree": {
+    "$className": "DataModel",
+    "ServerScriptService": {
+      "$path": "ServerScriptService"
+    },
+    "StarterPlayer": {
+      "$className": "StarterPlayer",
+      "StarterPlayerScripts": {
+        "$path": "StarterPlayer/StarterPlayerScripts"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit restores the default.project.json file that was accidentally deleted during a repository reset. This file is critical for the Rojo development workflow.