### PR TITLE
fix(client): attempt to fix syntax error in NumberLink.lua

### DIFF
--- a/StarterPlayer/StarterPlayerScripts/MiniGames/NumberLink.lua
+++ b/StarterPlayer/StarterPlayerScripts/MiniGames/NumberLink.lua
@@ -79,10 +79,15 @@ function NumberLink:Run(machine, puzzleData, currentProgress, neededProgress)
     end
 
     local function onDragEnd()
-        if not isDragging then return end
+        if not isDragging then
+            return
+        end
         local lastCell = currentPath[#currentPath]
         local startCell = currentPath[1]
-        if not startCell then isDragging = false; return end
+        if not startCell then
+            isDragging = false
+            return
+        end
         local partnerCell = self.endpoints[startCell].partner
         if lastCell == partnerCell then
             self:finalizePath(currentPath, activeColor)


### PR DESCRIPTION
This commit attempts to fix a subtle syntax error in the `NumberLink.lua` module that was causing the client scripts to fail to load.

The error `Expected identifier, got 'end'` was traced to the `NumberLink.lua` file. This change modifies the structure of two `if` statements within the `onDragEnd` local function, changing them from single-line to multi-line blocks. This does not alter the logic but is intended to resolve any potential parsing issues that may have been causing the error.