### PR TITLE
fix: resolve critical server and client syntax errors

### DIFF
--- a/ServerScriptService/MachineManager.server.lua
+++ b/ServerScriptService/MachineManager.server.lua
@@ -30,7 +30,7 @@ local machineProgress = {}
 local activePlayers = {} -- [player] = machineInstance
 
 -- Pre-defined puzzles for Number Link.
-local numberLinkPuzzles = {{8, {start=1,end=18}, {start=3,end=27}, {start=5,end=30}, {start=8,end=48}, {start=33,end=57}, {start=38,end=63}}}
+local numberLinkPuzzles = {{8, {start=1,endPoint=18}, {start=3,endPoint=27}, {start=5,endPoint=30}, {start=8,endPoint=48}, {start=33,endPoint=57}, {start=38,endPoint=63}}}
 
 local function triggerNewMemoryGame(player, machine, progress)
 	local gridSize = 3; local patternLength = 5

--- a/StarterPlayer/StarterPlayerScripts/MachineUIController.client.lua
+++ b/StarterPlayer/StarterPlayerScripts/MachineUIController.client.lua
@@ -131,10 +131,14 @@ local function runNumberLinkGame(machine, puzzleData, currentProgress, neededPro
 	local pairColors = {Color3.fromRGB(255, 87, 87), Color3.fromRGB(87, 255, 87), Color3.fromRGB(87, 87, 255), Color3.fromRGB(255, 255, 87), Color3.fromRGB(255, 87, 255), Color3.fromRGB(87, 255, 255)}
 	for i = 2, #puzzleData do
 		local pairInfo = puzzleData[i]
-		local color = pairColors[i - 1]
-		endpoints[pairInfo.start] = { color = color, partner = pairInfo.end }
-		endpoints[pairInfo.end] = { color = color, partner = pairInfo.start }
-		paths[color] = {}
+		if pairInfo then
+			local color = pairColors[i - 1]
+			local startPos = pairInfo.start
+			local endPos = pairInfo.endPoint
+			endpoints[startPos] = { color = color, partner = endPos }
+			endpoints[endPos] = { color = color, partner = startPos }
+			paths[color] = {}
+		end
 	end
 
 	local function checkWinCondition()


### PR DESCRIPTION
- Corrects a syntax error in MachineManager.server.lua by replacing the reserved keyword `end` with `endPoint`.
- Updates MachineUIController.client.lua to use the new `endPoint` key and fixes an additional syntax error in the same file.

These changes should resolve the server and client crashes.