### PR TITLE
fix: Add missing permissions to PR automation workflow

### DIFF
--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   pull-request:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: pull-request
         uses: "repo-sync/pull-request@v2"


### PR DESCRIPTION
This commit adds the `pull-requests: write` permission to the `create-pr` workflow. This is necessary for the action to be able to create pull requests in repositories with more restrictive default permissions.

This should fix the issue where the automation was failing silently.