### PR TITLE
debug(combat): Add diagnostic print for Killer attack

### DIFF
--- a/ServerScriptService/PlayerManager.lua
+++ b/ServerScriptService/PlayerManager.lua
@@ -61,6 +61,7 @@ function PlayerManager:OnCharacterAdded(player: Player, character: Model)
 	clickDetector.Parent = humanoid
 
 	clickDetector.MouseClick:Connect(function(attackerPlayer)
+		print("DEBUG: Click detected on " .. player.Name .. " by " .. attackerPlayer.Name)
 		self:KillerAttack(attackerPlayer, player)
 	end)
 


### PR DESCRIPTION
This is a non-functional change intended for debugging purposes.

A `print` statement has been added to the `MouseClick` event handler in the `PlayerManager`. This will log a message to the server console whenever a player is clicked.

This will help determine if the Killer's click-to-attack functionality is failing because the `ClickDetector` is not firing, or because the logic within the `KillerAttack` function is flawed.