### PR TITLE
Hotfix: Re-apply DataManager fix to prevent player kick

### DIFF
--- a/ServerScriptService/DataManager.lua
+++ b/ServerScriptService/DataManager.lua
@@ -41,9 +41,13 @@ function DataManager:LoadData(player: Player)
 			print("No data found for " .. player.Name .. ". Creating default data.")
 		end
 	else
-		warn("Failed to load data for " .. player.Name .. "! Reason: " .. tostring(data))
-		-- Kick the player or handle the error appropriately
-		player:Kick("There was an error loading your data. Please rejoin.")
+		warn("Failed to load data for " .. player.Name .. "! Reason: " .. tostring(data) .. ". Loading default data instead.")
+		-- If data loading fails, create default data to allow the player to join.
+		-- This is crucial for testing in Studio where DataStore API access might be disabled.
+		sessionData[player] = {
+			Currency = 0,
+			Unlocks = {}
+		}
 	end
 end
 


### PR DESCRIPTION
This commit re-applies a critical fix to `DataManager.lua` that was accidentally reverted during a previous documentation update.

The original fix prevents the server from kicking players when it fails to load their data from the DataStore service (a common occurrence in Roblox Studio). Instead of kicking the player, it now logs a warning and loads default data, allowing development and testing to proceed.

This regression was caused by a `reset_all()` command used to clean the working directory for a documentation commit. My apologies for this oversight.